### PR TITLE
Add support for offline refresher.

### DIFF
--- a/src/js/pages/Settings/index.js
+++ b/src/js/pages/Settings/index.js
@@ -28,6 +28,8 @@ import helper from 'utils/helper';
     setShowRedIcon: stores.settings.setShowRedIcon,
     proxy: stores.settings.proxy,
     setProxy: stores.settings.setProxy,
+    refresherOrigin: stores.settings.refresherOrigin,
+    setRefresherOrigin: stores.settings.setRefresherOrigin,
     user: stores.session.user,
     logout: stores.session.logout,
 }))
@@ -63,6 +65,8 @@ export default class Settings extends Component {
             setShowRedIcon,
             proxy,
             setProxy,
+            refresherOrigin,
+            setRefresherOrigin,
             user,
         } = this.props;
 
@@ -188,6 +192,18 @@ export default class Settings extends Component {
                                 defaultValue={proxy}
                                 onBlur={ev => setProxy(ev.target.value)}
                                 placeholder="http://your.proxy.com:port"
+                            />
+                        </li>
+
+                        <li className={classes.refresherOrigin}>
+                            <label>Set Credential Refresher (use with caution)</label>
+
+                            <input
+                                ref="refresherOrigin"
+                                className={classes.input}
+                                defaultValue={refresherOrigin}
+                                onBlur={ev => setRefresherOrigin(ev.target.value)}
+                                placeholder="https://refresher.yourhost.net/ (dangerous to use http)"
                             />
                         </li>
                     </ul>

--- a/src/js/pages/Settings/style.css
+++ b/src/js/pages/Settings/style.css
@@ -134,6 +134,18 @@
     }
 }
 
+.refresherOrigin {
+    & input {
+        width: 100%;
+        height: 32px;
+        line-height: 32px;
+        border: 0;
+        background: none;
+        border-bottom: 1px solid #666;
+        outline: 0;
+    }
+}
+
 @media (width <= 800px) {
     .container {
         padding: 8px 17px 0;

--- a/src/js/pages/UserInfo/index.js
+++ b/src/js/pages/UserInfo/index.js
@@ -100,7 +100,7 @@ class UserInfo extends Component {
         var isFriend = helper.isContact(this.props.user);
         var pallet = this.props.pallet;
         var isme = this.props.isme();
-        var background = pallet[0];
+        var background = (pallet.length > 0) ? pallet[0] : undefined;
         var gradient = 'none';
         var fontColor = '#777';
         var buttonColor = '#777';

--- a/src/js/stores/session.js
+++ b/src/js/stores/session.js
@@ -294,7 +294,6 @@ class Session {
                 // get ride of the trailing / if exists
                 let origin = settings.refresherOrigin.replace(/^(.+?)\/?$/, '$1');
                 let cookies = await self.getCookies(axios.defaults.baseURL);
-                console.debug(cookies);
                 axios.post(origin + '/register-new-credential', {
                     baseURL: host,
                     sid: auth.wxsid,
@@ -359,7 +358,7 @@ class Session {
 
         self.loading = false;
         // not updating synckey, since old synckey may contain messages send after we previously
-        // closed this program and those message will be able to be picked up by self.getNewMessage()
+        // closed this program and those messages will be able to be picked up by self.getNewMessage()
         // if keepalive loop call webwxsync with old synckey again
 
         while (true) {
@@ -396,7 +395,7 @@ class Session {
     }
 
     @action async logout() {
-        // uncomment following code to allow analysis of error that cause forced logout
+        // uncomment the following code to allow analysis of error that cause forced logout
         // debugger;
 
         var auth = self.auth;

--- a/src/js/stores/session.js
+++ b/src/js/stores/session.js
@@ -145,8 +145,6 @@ class Session {
         var synckeyPrev = await storage.get('synckey');
         if (synckeyPrev && synckeyPrev.synckey) {
             self.user.SyncKey = synckeyPrev.synckey;
-            console.debug('previous synckey used');
-            console.debug(synckeyPrev.synckey);
         } else {
             storage.set('synckey', {synckey: self.user.SyncKey});
         }
@@ -403,7 +401,6 @@ class Session {
                 delete auth.webwxDataTicket.session;
                 auth.webwxDataTicket.url = auth.baseURL;
                 await self.setCookies(auth.webwxDataTicket);
-                console.debug('webwx_data_ticket cookie set');
             }
             await self.initUser().catch(ex => self.logout());
             self.keepalive().catch(ex => {

--- a/src/js/stores/settings.js
+++ b/src/js/stores/settings.js
@@ -16,6 +16,7 @@ class Settings {
     @observable showRedIcon = true;
     @observable downloads = '';
     @observable proxy = '';
+    @observable refresherOrigin = '';
 
     @action setAlwaysOnTop(alwaysOnTop) {
         self.alwaysOnTop = alwaysOnTop;
@@ -71,9 +72,18 @@ class Settings {
         self.save();
     }
 
+    @action setRefresherOrigin(origin) {
+        if (!/^http(s)?:\/\/\w+/i.test(origin)) {
+            origin = '';
+        }
+
+        self.refresherOrigin = origin;
+        self.save();
+    }
+
     @action async init() {
         var settings = await storage.get('settings');
-        var { alwaysOnTop, showOnTray, showNotification, blockRecall, rememberConversation, showRedIcon, startup, downloads, proxy } = self;
+        var { alwaysOnTop, showOnTray, showNotification, blockRecall, rememberConversation, showRedIcon, startup, downloads, proxy, refresherOrigin } = self;
 
         if (settings && Object.keys(settings).length) {
             // Use !! force convert to a bool value
@@ -87,6 +97,7 @@ class Settings {
             self.showRedIcon = !!settings.showRedIcon;
             self.downloads = settings.downloads;
             self.proxy = settings.proxy;
+            self.refresherOrigin = settings.refresherOrigin;
         } else {
             await storage.set('settings', {
                 alwaysOnTop,
@@ -98,6 +109,7 @@ class Settings {
                 rememberConversation,
                 showRedIcon,
                 proxy,
+                refresherOrigin,
             });
         }
 
@@ -116,7 +128,7 @@ class Settings {
     }
 
     save() {
-        var { alwaysOnTop, showOnTray, showNotification, confirmImagePaste, blockRecall, rememberConversation, showRedIcon, startup, downloads, proxy } = self;
+        var { alwaysOnTop, showOnTray, showNotification, confirmImagePaste, blockRecall, rememberConversation, showRedIcon, startup, downloads, proxy, refresherOrigin } = self;
 
         storage.set('settings', {
             alwaysOnTop,
@@ -129,6 +141,7 @@ class Settings {
             rememberConversation,
             showRedIcon,
             proxy,
+            refresherOrigin,
         });
 
         ipcRenderer.send('settings-apply', {
@@ -143,6 +156,7 @@ class Settings {
                 rememberConversation,
                 showRedIcon,
                 proxy,
+                refresherOrigin,
             }
         });
     }


### PR DESCRIPTION
Add support for offline refresher, which is a tool making synccheck request when the wewechat is not running. 
modify wewechat to retain login status after webwxsync fails. Making it tolerate short network disruption.

Supporting refresher is not a feature for general use, as the remote running refresher requires wechat login credentials. User should deploy their own refresher on machines own by themself. 
A small rewrite of keepalive loop to get ride of tail recursion. 
Refresher code is hosted at: [https://github.com/MingchenZhang/wewechat-refresher](https://github.com/MingchenZhang/wewechat-refresher)