### PR TITLE
Changed to new browser-md5-file API that is introduced in 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "auto-launch": "^5.0.1",
     "axios": "^0.18.0",
-    "browser-md5-file": "^1.0.0",
+    "browser-md5-file": "1.1.1",
     "classname": "^0.0.0",
     "delegate": "^3.1.3",
     "electron-context-menu": "^0.10.0",

--- a/src/js/utils/helper.js
+++ b/src/js/utils/helper.js
@@ -1,7 +1,7 @@
 
 import { remote, ipcRenderer } from 'electron';
 import axios from 'axios';
-import MD5 from 'browser-md5-file';
+import BMF from 'browser-md5-file';
 
 import session from '../stores/session';
 
@@ -296,7 +296,7 @@ const helper = {
 
     md5: (file) => {
         return new Promise((resolve, reject) => {
-            MD5(file, (err, md5) => {
+            (new BMF()).md5(file, (err, md5) => {
                 resolve(err ? false : md5);
             });
         });


### PR DESCRIPTION
browser-md5-file npm package 1.1.0 made a breaking change to its API. This is inappropriate to happen in a minor version bump.
This commit specifies the version number in package.json to prevent future issue and updates the md5 routine to call in 1.1.0 API format.